### PR TITLE
Make recipe serializers thread safe

### DIFF
--- a/src/main/java/igentuman/nc/recipes/serializers/BoilingRecipeSerializer.java
+++ b/src/main/java/igentuman/nc/recipes/serializers/BoilingRecipeSerializer.java
@@ -2,6 +2,7 @@ package igentuman.nc.recipes.serializers;
 
 import com.google.gson.JsonObject;
 import igentuman.nc.NuclearCraft;
+import igentuman.nc.recipes.ingredient.FluidStackIngredient;
 import igentuman.nc.recipes.ingredient.ItemStackIngredient;
 import igentuman.nc.recipes.type.NcRecipe;
 import net.minecraft.network.FriendlyByteBuf;
@@ -18,8 +19,8 @@ public class BoilingRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSe
     @Override
     public @NotNull RECIPE fromJson(@NotNull ResourceLocation recipeId, @NotNull JsonObject json) {
 
-        inputFluidsFromJson(json, recipeId);
-        outputFluidsFromJson(json, recipeId);
+        FluidStackIngredient[] inputFluids = inputFluidsFromJson(json, recipeId);
+        FluidStackIngredient[] outputFluids = outputFluidsFromJson(json, recipeId);
 
         double heatRequired = 1D;
         try {
@@ -34,8 +35,11 @@ public class BoilingRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSe
     @Override
     public RECIPE fromNetwork(@NotNull ResourceLocation recipeId, @NotNull FriendlyByteBuf buffer) {
         try {
+            ItemStackIngredient[] inputItems = readItems(buffer);
+            ItemStackIngredient[] outputItems = readItems(buffer);
+            FluidStackIngredient[] inputFluids = readFluids(buffer);
+            FluidStackIngredient[] outputFluids = readFluids(buffer);
 
-            readIngredients(buffer);
             double heatRequired = buffer.readDouble();
             double powerModifier = buffer.readDouble();
             double radiation = buffer.readDouble();

--- a/src/main/java/igentuman/nc/recipes/serializers/CoolantRecipeSerializer.java
+++ b/src/main/java/igentuman/nc/recipes/serializers/CoolantRecipeSerializer.java
@@ -2,6 +2,7 @@ package igentuman.nc.recipes.serializers;
 
 import com.google.gson.JsonObject;
 import igentuman.nc.NuclearCraft;
+import igentuman.nc.recipes.ingredient.FluidStackIngredient;
 import igentuman.nc.recipes.ingredient.ItemStackIngredient;
 import igentuman.nc.recipes.type.NcRecipe;
 import net.minecraft.network.FriendlyByteBuf;
@@ -18,8 +19,8 @@ public class CoolantRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSe
     @Override
     public @NotNull RECIPE fromJson(@NotNull ResourceLocation recipeId, @NotNull JsonObject json) {
 
-        inputFluidsFromJson(json, recipeId);
-        outputFluidsFromJson(json, recipeId);
+        FluidStackIngredient[] inputFluids = inputFluidsFromJson(json, recipeId);
+        FluidStackIngredient[] outputFluids = outputFluidsFromJson(json, recipeId);
 
         double coolingRate = 1000D;
         try {
@@ -34,7 +35,11 @@ public class CoolantRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSe
     @Override
     public RECIPE fromNetwork(@NotNull ResourceLocation recipeId, @NotNull FriendlyByteBuf buffer) {
         try {
-            readIngredients(buffer);
+            ItemStackIngredient[] inputItems = readItems(buffer);
+            ItemStackIngredient[] outputItems = readItems(buffer);
+            FluidStackIngredient[] inputFluids = readFluids(buffer);
+            FluidStackIngredient[] outputFluids = readFluids(buffer);
+
             double coolingRate = buffer.readDouble();
             double powerModifier = buffer.readDouble();
             double radiation = buffer.readDouble();

--- a/src/main/java/igentuman/nc/recipes/serializers/FusionRecipeSerializer.java
+++ b/src/main/java/igentuman/nc/recipes/serializers/FusionRecipeSerializer.java
@@ -1,6 +1,8 @@
 package igentuman.nc.recipes.serializers;
 
 import igentuman.nc.NuclearCraft;
+import igentuman.nc.recipes.ingredient.FluidStackIngredient;
+import igentuman.nc.recipes.ingredient.ItemStackIngredient;
 import igentuman.nc.recipes.type.NcRecipe;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
@@ -15,7 +17,10 @@ public class FusionRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSer
     @Override
     public RECIPE fromNetwork(@NotNull ResourceLocation recipeId, @NotNull FriendlyByteBuf buffer) {
         try {
-            readIngredients(buffer);
+            ItemStackIngredient[] inputItems = readItems(buffer);
+            ItemStackIngredient[] outputItems = readItems(buffer);
+            FluidStackIngredient[] inputFluids = readFluids(buffer);
+            FluidStackIngredient[] outputFluids = readFluids(buffer);
 
             double timeModifier = buffer.readDouble();
             double powerModifier = buffer.readDouble();

--- a/src/main/java/igentuman/nc/recipes/serializers/OreVeinRecipeSerializer.java
+++ b/src/main/java/igentuman/nc/recipes/serializers/OreVeinRecipeSerializer.java
@@ -20,8 +20,10 @@ public class OreVeinRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSe
     @Override
     public RECIPE fromNetwork(@NotNull ResourceLocation recipeId, @NotNull FriendlyByteBuf buffer) {
         try {
-
-            readIngredients(buffer);
+            ItemStackIngredient[] inputItems = readItems(buffer);
+            ItemStackIngredient[] outputItems = readItems(buffer);
+            FluidStackIngredient[] inputFluids = readFluids(buffer);
+            FluidStackIngredient[] outputFluids = readFluids(buffer);
 
             double timeModifier = buffer.readDouble();
             double powerModifier = buffer.readDouble();

--- a/src/main/java/igentuman/nc/recipes/serializers/TurbineRecipeSerializer.java
+++ b/src/main/java/igentuman/nc/recipes/serializers/TurbineRecipeSerializer.java
@@ -24,8 +24,8 @@ public class TurbineRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSe
     @Override
     public @NotNull RECIPE fromJson(@NotNull ResourceLocation recipeId, @NotNull JsonObject json) {
 
-        inputItemsFromJson(json, recipeId);
-        outputItemsFromJson(json, recipeId);
+        FluidStackIngredient[] inputFluids = inputFluidsFromJson(json, recipeId);
+        FluidStackIngredient[] outputFluids = outputFluidsFromJson(json, recipeId);
 
         double heatRequired = 1D;
         try {
@@ -40,8 +40,10 @@ public class TurbineRecipeSerializer<RECIPE extends NcRecipe> extends NcRecipeSe
     @Override
     public RECIPE fromNetwork(@NotNull ResourceLocation recipeId, @NotNull FriendlyByteBuf buffer) {
         try {
-
-            readIngredients(buffer);
+            ItemStackIngredient[] inputItems = readItems(buffer);
+            ItemStackIngredient[] outputItems = readItems(buffer);
+            FluidStackIngredient[] inputFluids = readFluids(buffer);
+            FluidStackIngredient[] outputFluids = readFluids(buffer);
 
             double heatRequired = buffer.readDouble();
             double powerModifier = buffer.readDouble();


### PR DESCRIPTION
This fixes an issue with KubeJS where NuclearCraft recipes get randomly corrupted or removes sometimes