### PR TITLE
Fix invalid shift+click item behaviour and item dupe exploit

### DIFF
--- a/src/main/java/igentuman/nc/container/ChamberTerminalContainer.java
+++ b/src/main/java/igentuman/nc/container/ChamberTerminalContainer.java
@@ -51,11 +51,11 @@ public class ChamberTerminalContainer extends AbstractContainerMenu {
             ItemStack stack = slot.getItem();
             itemstack = stack.copy();
             if(slot instanceof NCSlotItemHandler.Output || slot instanceof NCSlotItemHandler.Input) {
-                if (!this.moveItemStackTo(stack, 0, 35, true)) {
+                if (!this.moveItemStackTo(stack, 0, 36, true)) {
                     return ItemStack.EMPTY;
                 }
             } else {
-                if (!this.moveItemStackTo(stack, slots.size()-3, slots.size()-1, true)) {
+                if (!this.moveItemStackTo(stack, slots.size()-2, slots.size(), true)) {
                     return ItemStack.EMPTY;
                 }
             }

--- a/src/main/java/igentuman/nc/container/FissionControllerContainer.java
+++ b/src/main/java/igentuman/nc/container/FissionControllerContainer.java
@@ -54,11 +54,11 @@ public class FissionControllerContainer extends AbstractContainerMenu {
             ItemStack stack = slot.getItem();
             itemstack = stack.copy();
             if(slot instanceof NCSlotItemHandler.Output || slot instanceof NCSlotItemHandler.Input) {
-                if (!this.moveItemStackTo(stack, 0, 35, true)) {
+                if (!this.moveItemStackTo(stack, 0, 36, true)) {
                     return ItemStack.EMPTY;
                 }
             } else {
-                if (!this.moveItemStackTo(stack, slots.size()-3, slots.size()-1, true)) {
+                if (!this.moveItemStackTo(stack, slots.size()-2, slots.size(), true)) {
                     return ItemStack.EMPTY;
                 }
             }

--- a/src/main/java/igentuman/nc/container/FissionPortContainer.java
+++ b/src/main/java/igentuman/nc/container/FissionPortContainer.java
@@ -59,11 +59,11 @@ public class FissionPortContainer extends AbstractContainerMenu {
             ItemStack stack = slot.getItem();
             itemstack = stack.copy();
             if(slot instanceof NCSlotItemHandler.Output || slot instanceof NCSlotItemHandler.Input) {
-                if (!this.moveItemStackTo(stack, 0, 35, true)) {
+                if (!this.moveItemStackTo(stack, 0, 36, true)) {
                     return ItemStack.EMPTY;
                 }
             } else {
-                if (!this.moveItemStackTo(stack, slots.size()-3, slots.size()-1, true)) {
+                if (!this.moveItemStackTo(stack, slots.size()-2, slots.size(), true)) {
                     return ItemStack.EMPTY;
                 }
             }


### PR DESCRIPTION
moveItemStackTo parameters are (stack, slotFromInclusive, slotToExclusive, reverse). There is no need to subtract -1 from slotTo and slotFrom.