### PR TITLE
Make fission glass not block light in AO calculation, hide radiation tooltips when radiation is disabled

### DIFF
--- a/src/main/java/igentuman/nc/block/fission/FissionCasingBlock.java
+++ b/src/main/java/igentuman/nc/block/fission/FissionCasingBlock.java
@@ -24,6 +24,11 @@ public class FissionCasingBlock extends MultiblockBlock {
     }
 
     @Override
+    public float getShadeBrightness(BlockState pState, BlockGetter pLevel, BlockPos pPos) {
+        return asItem().toString().matches(".*glass") ? 1.0F : 0.2F;
+    }
+
+    @Override
     @Deprecated
     public boolean skipRendering(@NotNull BlockState state, @NotNull BlockState adjacentBlockState, @NotNull Direction side) {
         return adjacentBlockState.getBlock().equals(this) && asItem().toString().matches(".*glass|.*slope.*");

--- a/src/main/java/igentuman/nc/handler/event/client/TooltipHandler.java
+++ b/src/main/java/igentuman/nc/handler/event/client/TooltipHandler.java
@@ -1,5 +1,6 @@
 package igentuman.nc.handler.event.client;
 
+import igentuman.nc.handler.config.RadiationConfig;
 import igentuman.nc.multiblock.fission.FissionBlocks;
 import igentuman.nc.radiation.ItemRadiation;
 import igentuman.nc.radiation.ItemShielding;
@@ -36,9 +37,11 @@ public class TooltipHandler {
         processedEvent = event;
         Item item = event.getItemStack().getItem();
         miscTooltips(event, event.getItemStack());
-        addRadiationLevelTooltip(event, item);
-        addShieldingTooltip(event, event.getItemStack());
-        addRadiationCleaningEffect(event, event.getItemStack());
+        if(RadiationConfig.RADIATION_CONFIG.ENABLED.get()) {
+            addRadiationLevelTooltip(event, item);
+            addShieldingTooltip(event, event.getItemStack());
+            addRadiationCleaningEffect(event, event.getItemStack());
+        }
         addModeratorTooltip(event, event.getItemStack());
     }
 


### PR DESCRIPTION
Two things that annoyed me a bit.

![image](https://github.com/user-attachments/assets/ab9664fa-12a1-4464-b808-c2a37d92d205)
Makes reactor glass look like this.

Also hides radiation tooltips if radiation is disabled. Fixes #140 