### PR TITLE
Fix countAdjacentFuelCells

### DIFF
--- a/src/main/java/igentuman/nc/multiblock/fission/FissionReactorMultiblock.java
+++ b/src/main/java/igentuman/nc/multiblock/fission/FissionReactorMultiblock.java
@@ -404,19 +404,12 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
                 if (isFuelCell(toCheck.revert().relative(d, l))) {
                     count += step;
                     break;
-                }
-
-                if(isModerator(toCheck.revert().relative(d, l))) {
+                } else if (isModerator(toCheck.revert().relative(d, l))) {
                     addIfNotExists(toCheck.revert().relative(d), allModerators);
-                    if(isFuelCell(toCheck.revert().relative(d, l + 1))) {
-                        count += step;
-                        break;
-                    }
+                } else {
+                    break;
                 }
             }
-        }
-        if(count == 0) {
-            count = 1;
         }
         return count;
     }


### PR DESCRIPTION
I saw commit be06bab851362eb2963fd4431cba92778ee7f1b2 and it seems like you were trying to recreate the neutron reach system from the old Nuclearcraft mod. But as it is, the count for fuel cells would increment even if separated by air or coolers (even though they should only be linked if adjacent or through moderator(s)), and the count would not increment if it is separated by more than 1 moderator. (See old implementation [here](https://youtube.com/watch?v=IIZur0OrqGY,t=404) and [here](https://youtu.be/IIZur0OrqGY?t=740)) Therefore, I rewrote the function so that it would function properly. I also removed the "if count == 0 then count = 1" statement because no where is fuelCellMultiplier multiplied or divided such that having it 0 would be problematic, and moderatorCellMultiplier already has 1 added to it after the countAdjacentFuelCells calculation anyway.