### PR TITLE
Fix Active Heat Sinks, Slight refactor

### DIFF
--- a/src/main/java/igentuman/nc/multiblock/fission/FissionReactorMultiblock.java
+++ b/src/main/java/igentuman/nc/multiblock/fission/FissionReactorMultiblock.java
@@ -35,11 +35,10 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
     public final HashMap<Long, HeatSinkBlock> validHeatSinks = new HashMap<>();
     protected final HashSet<Long> moderators = new HashSet<>();
     protected final HashSet<Long> irradiators = new HashSet<>();
-    protected final HashSet<Long> heatSinks = new HashSet<>();
     public final HashSet<Long> fuelCells = new HashSet<>();
     protected final HashSet<Long> allModerators = new HashSet<>();
     protected final HashSet<Long> validIrradiators = new HashSet<>();
-    protected final HashSet<Long> activeCoolers = new HashSet<>();
+    protected final HashSet<Long> activeHeatSinks = new HashSet<>();
     protected final HashSet<Long> allHeatSinks = new HashSet<>();
     protected final HashMap<String, HashSet<BlockPos>> indexedHeatSinks = new HashMap<>();
     protected final HashMap<BlockPos, String> reversedIndexedHeatSinks = new HashMap<>();
@@ -102,31 +101,18 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
         MultiblockHandler.get(getLevel().dimension()).addMultiblock(this);
     }
 
-    public Map<Long, HeatSinkBlock> validHeatSinks() {
-        if(validHeatSinks.isEmpty()) {
-            for(long packedPos: allHeatSinks) {
-                BlockPos hpos = BlockPos.of(packedPos);
-                Block block = getBlockState(hpos).getBlock();
-                if(block instanceof HeatSinkBlock hs) {
-                    if(hs.isValid(getLevel(), hpos, this)) {
-                        validHeatSinks.put(packedPos, hs);
-                        if(hs.isActive()) {
-                            activeCoolers.add(packedPos);
-                            addActiveCoolant(hs.def.name.replace("active_", ""));
-                        }
-                    }
-                }
-            }
-        }
-        controllerBE().heatSinksCount = validHeatSinks.size();
-        return validHeatSinks;
-    }
-
     private void addActiveCoolant(String name) {
         if(!coolantPerTick.containsKey(name)) {
             coolantPerTick.put(name, 0);
         }
         coolantPerTick.replace(name, coolantPerTick.get(name)+FISSION_CONFIG.ACTIVE_HEATSINK_COOLANT_PER_TICK.get());
+    }
+
+    private void removeActiveCoolant(String name) {
+        coolantPerTick.replace(name, coolantPerTick.get(name)-FISSION_CONFIG.ACTIVE_HEATSINK_COOLANT_PER_TICK.get());
+        if (coolantPerTick.get(name) == 0) {
+            coolantPerTick.remove(name);
+        }
     }
 
     @Override
@@ -175,7 +161,7 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
         reversedIndexedHeatSinks.clear();
         allModerators.clear();
         validIrradiators.clear();
-        activeCoolers.clear();
+        activeHeatSinks.clear();
         super.validate();
     }
 
@@ -214,9 +200,9 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
         controllerBE().irradiationLines = irradiationLines;
         controllerBE().allIrradiators = irradiators.size();
         controllerBE().validIrradiators = validIrradiators.size();
-        controllerBE().heatSinksCount = heatSinks.size();
+        controllerBE().heatSinksCount = validHeatSinks.size();
         controllerBE().allHeatSinks = allHeatSinks.size();
-        controllerBE().activeCoolingHeatsinks = activeCoolers.size();
+        controllerBE().activeCoolingHeatsinks = activeHeatSinks.size();
         controllerBE().moderatorsCount = moderators.size();
         controllerBE().allModerators = allModerators.size();
         controllerBE().moderatorAttachments = moderatorAttachments;
@@ -265,14 +251,20 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
             long pos = hsPos.asLong();
             if (isHeatSinkValid(hsPos)) {
                 HeatSinkBlock hb = validHeatSinks.get(pos);
-                addIfNotExists(pos, heatSinks);
                 addSecondConnectionsToFuelCell(hsPos);
                 if(hb.isActive()) {
-                    addIfNotExists(pos, activeCoolers);
-                    addActiveCoolant(hb.def.name.replace("active_", ""));
+                    if (!activeHeatSinks.contains(pos)) {
+                        addActiveCoolant(hb.def.name.replace("active_", ""));
+                    }
+                    addIfNotExists(pos, activeHeatSinks);
                 }
             } else {
+                if (activeHeatSinks.contains(pos)) {
+                    activeHeatSinks.remove(pos);
+                    removeActiveCoolant(validHeatSinks.get(pos).def.name.replace("active_", ""));
+                }
                 validHeatSinks.remove(pos);
+                removeSecondConnectionsToFuelCell(hsPos);
             }
         }
     }
@@ -379,6 +371,13 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
         }
     }
 
+    private void removeSecondConnectionsToFuelCell(BlockPos toCheck) {
+        secondFuelCellConnectionPos.remove(toCheck.asLong());
+        for(Direction d : Direction.values()) {
+            secondFuelCellConnectionPos.remove(toCheck.relative(d).asLong());
+        }
+    }
+
     private void addDirectFuelCellConnection(BlockPos toCheck) {
         addIfNotExists(toCheck, directFuelCellConnectionPos);
         for(Direction d : Direction.values()) {
@@ -449,13 +448,13 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
                     moderators.remove(pPos);
                     allModerators.remove(pPos);
                 }
-                heatSinks.remove(packedPos);
                 String posHeatSink = reversedIndexedHeatSinks.get(pos);
                 reversedIndexedHeatSinks.remove(pos);
                 indexedHeatSinks.get(posHeatSink).remove(pos);
                 if (indexedHeatSinks.get(posHeatSink).isEmpty()) {
                     indexedHeatSinks.remove(posHeatSink);
                 }
+                activeHeatSinks.remove(packedPos);
                 allModerators.remove(packedPos);
                 allHeatSinks.remove(packedPos);
                 fuelCells.remove(packedPos);
@@ -498,7 +497,7 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
     public double countCooling(boolean forceCheck) {
         if(forceCheck) {
             heatSinkCooling = 0;
-            for (HeatSinkBlock hs : validHeatSinks().values()) {
+            for (HeatSinkBlock hs : validHeatSinks.values()) {
                 heatSinkCooling += hs.heat;
             }
         }

--- a/src/main/java/igentuman/nc/multiblock/fission/FissionReactorRegistration.java
+++ b/src/main/java/igentuman/nc/multiblock/fission/FissionReactorRegistration.java
@@ -132,6 +132,7 @@ public class FissionReactorRegistration {
         HashMap<String, HeatSinkDef> tmp = new HashMap<>();
         ValidationScheduler scheduler = new ValidationScheduler();
         List<JsonArray> data = JSONUtil.loadAllJsonFromConfig("heat_sinks");
+        Pattern activeCheck = Pattern.compile("^(?!.*active_).+_heat_sink$");
         if(data == null) {
             return tmp;
         }
@@ -147,10 +148,20 @@ public class FissionReactorRegistration {
                     for (String rule: heatSink.rules) {
                         String[] conditionParts = rule.split("=|-|>|<|\\^");
                         for (String block: conditionParts[0].split("\\|")) {
+                            String blockName = block;
                             if (!block.contains(":")) {
-                                block = MODID + ":" + block;
+                                blockName = MODID + ":" + block;
                             }
-                            scheduler.graphAddEdge(name + "_heat_sink", block);
+                            scheduler.graphAddEdge(name + "_heat_sink", blockName);
+                            if (activeCheck.matcher(block).matches()) {
+                                if (block.contains(":")) {
+                                    String[] blockParts = block.split(":");
+                                    blockName = blockParts[0] + ":active_" + blockParts[1];
+                                } else {
+                                    blockName = MODID + ":active_" + block;
+                                }
+                                scheduler.graphAddEdge(name + "_heat_sink", blockName);
+                            }
                         }
                     }
                 }

--- a/src/main/java/igentuman/nc/multiblock/fission/HeatSinkDef.java
+++ b/src/main/java/igentuman/nc/multiblock/fission/HeatSinkDef.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static igentuman.nc.NuclearCraft.MODID;
+import static igentuman.nc.handler.config.FissionConfig.FISSION_CONFIG;
 import static igentuman.nc.util.NcUtils.rlFromString;
 import static igentuman.nc.util.StackUtils.getItemsByTagKey;
 import static igentuman.nc.util.TagUtil.getFirstMatchingFluidByTag;
@@ -95,14 +96,25 @@ public class HeatSinkDef {
 
     private List<String> collectBlocks(String[] blocks) {
         List<String> tmp = new ArrayList<>();
+        Pattern activeCheck = Pattern.compile("^(?!.*active_).+_heat_sink$");
         for(String block: blocks) {
             if(block.contains("#")) {
                 tmp.addAll(getItemsByTagKey(block.replace("#","")));
             } else {
+                String blockName = block;
                 if(!block.contains(":")) {
-                    block = MODID+":"+block;
+                    blockName = MODID + ":" + block;
                 }
-                tmp.add(block);
+                tmp.add(blockName);
+                if (FISSION_CONFIG.ACTIVE_HEATSINK_PRIME.get() && activeCheck.matcher(block).matches()) {
+                    if (block.contains(":")) {
+                        String[] blockParts = block.split(":");
+                        blockName = blockParts[0] + ":active_" + blockParts[1];
+                    } else {
+                        blockName = MODID + ":active_" + block;
+                    }
+                    tmp.add(blockName);
+                }
             }
         }
         return tmp;


### PR DESCRIPTION
This pull request fixes coolant use for active heat sinks and implements "active heatsink prime" (active coolers will be counted in placement rules for other heat sinks). The way that it is implemented is that if active heatsink prime is true, and heat sink A has defined heat sink B in its dependencies, then active heat sink B will also allow it to work. However, if only active heat sink B is defined, only active heat sink B will work, and normal heat sink B will not allow heat sink A to be valid. If active heatsink prime is false, the previous implementation applies. (Maybe update README to include instructions on this?)