### PR TITLE
Fix fuel cell validation

### DIFF
--- a/src/main/java/igentuman/nc/multiblock/fission/FissionReactorMultiblock.java
+++ b/src/main/java/igentuman/nc/multiblock/fission/FissionReactorMultiblock.java
@@ -162,6 +162,11 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
         allModerators.clear();
         validIrradiators.clear();
         activeHeatSinks.clear();
+        allBlocks.clear();
+        fuelCells.clear();
+        irradiators.clear();
+        directFuelCellConnectionPos.clear();
+        secondFuelCellConnectionPos.clear();
         super.validate();
     }
 
@@ -447,6 +452,8 @@ public class FissionReactorMultiblock extends AbstractMultiblock {
                     long pPos = pos.relative(dir).asLong();
                     moderators.remove(pPos);
                     allModerators.remove(pPos);
+                    directFuelCellConnectionPos.remove(pPos);
+                    secondFuelCellConnectionPos.remove(pPos);
                 }
                 String posHeatSink = reversedIndexedHeatSinks.get(pos);
                 reversedIndexedHeatSinks.remove(pos);


### PR DESCRIPTION
Really simple fix this time, but still important: Fixes issue where breaking the multiblock, then breaking the fuel cells, then fixing the multiblock can result in fuel cells still erroneously stored in cache. (Which can make fission reactors heat up for no reason until world relog, since heat sinks are properly updated)