### PR TITLE
Fix upgrade_tier not persisting or applying to GT energy output voltage

### DIFF
--- a/src/main/java/igentuman/nc/block/MultiblockControllerBlock.java
+++ b/src/main/java/igentuman/nc/block/MultiblockControllerBlock.java
@@ -50,7 +50,8 @@ public class MultiblockControllerBlock extends HorizontalDirectionalBlock {
         if (stack.hasTag()) {
             MultiblockControllerBE tileEntity = (MultiblockControllerBE) world.getExistingBlockEntity(pos);
             CompoundTag nbtData = stack.getOrCreateTag();
-            tileEntity.updateEnergyTier(nbtData.getInt("upgrade_tier"));
+            tileEntity.upgrade_tier = nbtData.getInt("upgrade_tier");
+            tileEntity.updateEnergyTier(tileEntity.upgrade_tier);
         }
     }
 

--- a/src/main/java/igentuman/nc/block/entity/MultiblockControllerBE.java
+++ b/src/main/java/igentuman/nc/block/entity/MultiblockControllerBE.java
@@ -162,6 +162,12 @@ public class MultiblockControllerBE extends NuclearCraftBE implements Multiblock
                 errorBlockPos = BlockPos.ZERO;
             }
             validationResult = ValidationResult.byId(infoTag.getInt("validationId"));
+            if (infoTag.contains("upgrade_tier")) {
+                upgrade_tier = infoTag.getInt("upgrade_tier");
+                // Re-apply the upgrade tier to the energy storage after a chunk reload,
+                // because the storage constructor only knows the base config tier.
+                updateEnergyTier(upgrade_tier);
+            }
         }
     }
 
@@ -205,6 +211,7 @@ public class MultiblockControllerBE extends NuclearCraftBE implements Multiblock
                 errorBlockPos = BlockPos.ZERO;
             }
             infoTag.putLong("erroredBlock", errorBlockPos.asLong());
+            infoTag.putInt("upgrade_tier", upgrade_tier);
             tag.remove("Info");
             tag.put("Info", infoTag);
         }

--- a/src/main/java/igentuman/nc/block/fusion/FusionCoreBlock.java
+++ b/src/main/java/igentuman/nc/block/fusion/FusionCoreBlock.java
@@ -205,6 +205,8 @@ public class FusionCoreBlock extends FusionBeBlock {
             CompoundTag tag = new CompoundTag();
             tag.put("Info", nbtData);
             tileEntity.load(tag);
+            tileEntity.upgrade_tier = nbtData.getInt("upgrade_tier");
+            tileEntity.updateEnergyTier(tileEntity.upgrade_tier);
         }
     }
 }


### PR DESCRIPTION
In short, the EU upgrade tiers did not do anything in game for the multiblocks or fusion reactor.

Three related bugs prevented the fusion (and other multiblock) energy upgrade tier from taking effect:

- MultiblockControllerBE.load() never read upgrade_tier from the Info NBT tag, so chunk reload always reset the energy storage to the config-default tier.
- MultiblockControllerBE.saveAdditional() never wrote upgrade_tier to the Info tag, so the value was silently lost on unload.
- FusionCoreBlock.setPlacedBy() called tileEntity.load() (which now reads the tag correctly) but didn't set tileEntity.upgrade_tier first, so the stored value remained 0. Same gap existed in MultiblockControllerBlock.setPlacedBy().

All three sites now read/write upgrade_tier and call updateEnergyTier() consistently.