### PR TITLE
Fix RF amplifier heat rate always returning 100 H/t

### DIFF
--- a/src/main/java/igentuman/nc/content/RFAmplifier.java
+++ b/src/main/java/igentuman/nc/content/RFAmplifier.java
@@ -139,7 +139,7 @@ public class RFAmplifier {
         }
 
         public int getHeatRate() {
-            return 100; //todo implement heat rate
+            return getHeat();
         }
     }
 }


### PR DESCRIPTION
RFAmplifierPrefab.getHeatRate() was a hardcoded stub, ignoring the per-tier heat field used by the tooltip (getHeat()). This meant every amplifier tier contributed exactly 100 H/t to accelerator heat generation regardless of tier, contradicting the displayed tooltip values (300/580/1140/2260/4500). Mirrors ElectromagnetBlock's correct pattern of delegating getHeatRate() to getHeat().